### PR TITLE
feat: add electrovalve calibration and inversion controls

### DIFF
--- a/Calibration.cpp
+++ b/Calibration.cpp
@@ -126,10 +126,13 @@ static String navBar(){
   return String(
     "<div class='bar'>"
       "<a class='btn' href='/defaut'>D\u00E9faut ESP32</a>"
-      "<a class='btn' href='/calib'>Calibration</a>"
+      "<a class='btn' href='/calib'>Calibration Joystick</a>"
+      "<a class='btn' href='/calev'>Calibration \u00E9lectrovannes</a>"
       "<a class='btn' href='/bridage'>Bridage axes</a>"
+      "<a class='btn' href='/invjoy'>Inversion Joystick</a>"
+      "<a class='btn' href='/invpad'>Inversion Manette</a>"
     "</div>"
-    "<style>.bar{display:flex;gap:8px;margin:10px 0 16px}"
+    "<style>.bar{display:flex;flex-wrap:wrap;gap:8px;margin:10px 0 16px}"
     ".btn{background:#334155;color:#e5e7eb;border:1px solid #1f2937;padding:8px 12px;border-radius:8px;text-decoration:none}"
     ".btn:hover{background:#475569}</style>"
   );

--- a/Controllers.cpp
+++ b/Controllers.cpp
@@ -3,6 +3,7 @@
 #include "Faults.h"
 #include "IOMap.h"
 #include "Calibration.h"
+#include "Inversion.h"
 
 ControllerPtr myControllers[BP32_MAX_GAMEPADS];
 uint32_t psHoldStartMs[BP32_MAX_GAMEPADS] = {0}, rlHoldStartMs[BP32_MAX_GAMEPADS] = {0};
@@ -187,6 +188,15 @@ void processControllers() {
   if (b & 0x0001) R1 = padMapMin[AX_R1]; else if (b & 0x0002) R1 = padMapMax[AX_R1];
   if (b & 0x0004) R2 = padMapMin[AX_R2]; else if (b & 0x0008) R2 = padMapMax[AX_R2];
 
+  if(invertPad[AX_X])  X  = padMapMin[AX_X]  + padMapMax[AX_X]  - X;
+  if(invertPad[AX_Y])  Y  = padMapMin[AX_Y]  + padMapMax[AX_Y]  - Y;
+  if(invertPad[AX_LX]) LX = padMapMin[AX_LX] + padMapMax[AX_LX] - LX;
+  if(invertPad[AX_LY]) LY = padMapMin[AX_LY] + padMapMax[AX_LY] - LY;
+  if(invertPad[AX_Z])  Z  = padMapMin[AX_Z]  + padMapMax[AX_Z]  - Z;
+  if(invertPad[AX_LZ]) LZ = padMapMin[AX_LZ] + padMapMax[AX_LZ] - LZ;
+  if(invertPad[AX_R1]) R1 = padMapMin[AX_R1] + padMapMax[AX_R1] - R1;
+  if(invertPad[AX_R2]) R2 = padMapMin[AX_R2] + padMapMax[AX_R2] - R2;
+
   if (pcaOK && safetyReady) {
     applyAxisToPair(0, X); applyAxisToPair(1, Y); applyAxisToPair(2, Z); applyAxisToPair(3, LX);
     applyAxisToPair(4, LY); applyAxisToPair(5, LZ); applyAxisToPair(6, R1); applyAxisToPair(7, R2);
@@ -216,6 +226,7 @@ bool getPadValues(int out[AX_COUNT], ControllerPtr ctl){
   out[AX_R1]=padNeutral[AX_R1]; out[AX_R2]=padNeutral[AX_R2]; uint16_t b=ctl->buttons();
   if(b&0x0001) out[AX_R1]=padMapMin[AX_R1]; else if(b&0x0002) out[AX_R1]=padMapMax[AX_R1];
   if(b&0x0004) out[AX_R2]=padMapMin[AX_R2]; else if(b&0x0008) out[AX_R2]=padMapMax[AX_R2];
+  for(int i=0;i<AX_COUNT;i++) if(invertPad[i]) out[i] = padMapMin[i] + padMapMax[i] - out[i];
   return true;
 }
 

--- a/ESP32_PVG32_Controller.ino
+++ b/ESP32_PVG32_Controller.ino
@@ -7,6 +7,8 @@
 #include "Controllers.h"
 #include "Calibration.h"
 #include "Bridage.h"
+#include "Inversion.h"
+#include "ValveCalib.h"
 #include "Faults.h"
 #include "FaultsPortal.h"
 #include "Portal.h"
@@ -30,8 +32,8 @@ void setup() {
   faultsBootCheck();       // Auto-test I2C (N2/N3/N4/N5 si besoin)
   calLoadOrDefault();      // Calibration joysticks (EEPROM)
   bridageLoadOrDefault();  // Bridage manette (EEPROM)
-  loadNeutralOffset();
-  updateNeutralWindow();
+  inversionLoadOrDefault(); // Inversions axes (EEPROM)
+  valveCalibLoad();        // Neutre/min/max électrovannes (EEPROM)
   controllersSetup();      // Bluepad32 (callbacks connect/disconnect)
 
   // Mode initial + neutralisation

--- a/FaultsPortal.cpp
+++ b/FaultsPortal.cpp
@@ -12,10 +12,13 @@ static String navBar(){
   return String(
     "<div class='bar'>"
       "<a class='btn' href='/defaut'>D\u00E9faut ESP32</a>"
-      "<a class='btn' href='/calib'>Calibration</a>"
+      "<a class='btn' href='/calib'>Calibration Joystick</a>"
+      "<a class='btn' href='/calev'>Calibration \u00E9lectrovannes</a>"
       "<a class='btn' href='/bridage'>Bridage axes</a>"
+      "<a class='btn' href='/invjoy'>Inversion Joystick</a>"
+      "<a class='btn' href='/invpad'>Inversion Manette</a>"
     "</div>"
-    "<style>.bar{display:flex;gap:8px;margin:10px 0 16px}"
+    "<style>.bar{display:flex;flex-wrap:wrap;gap:8px;margin:10px 0 16px}"
     ".btn{background:#334155;color:#e5e7eb;border:1px solid #1f2937;padding:8px 12px;border-radius:8px;text-decoration:none}"
     ".btn:hover{background:#475569}</style>"
   );

--- a/IOMap.cpp
+++ b/IOMap.cpp
@@ -3,6 +3,7 @@
 #include "Faults.h"
 #include "Calibration.h"
 #include "Bridage.h"
+#include "Inversion.h"
 #include <Wire.h>
 #include <EEPROM.h>
 
@@ -19,7 +20,7 @@ bool pcaOK=true;
 bool adsOK[2]={false,false};
 int neutralOffset=512;
 int joyNeutralMin=0, joyNeutralMax=0;
-static int mapMin=255, mapMax=768;
+int valveMin=255, valveMax=768;
 
 static const int NEUTRAL_HALF_WINDOW = 30;
 static int lastOffset = 512;
@@ -106,8 +107,8 @@ Axes8 mapADSAll(const ADSRaw& r){
 
   int *v = (int*)&a;
   for(int i=0;i<8;i++){
-    if(v[i] < mapMin) v[i] = mapMin;
-    if(v[i] > mapMax) v[i] = mapMax;
+    if(v[i] < valveMin) v[i] = valveMin;
+    if(v[i] > valveMax) v[i] = valveMax;
   }
   return a;
 }
@@ -151,10 +152,10 @@ void applyAxisToPair(uint8_t pwmCh, int val){
   bool active = false; // true when axis is outside neutral window
 
   if (val < joyNeutralMin){
-    duty = mapf((float)val, (float)mapMin, (float)joyNeutralMin, DUTY_MIN, DUTY_MID) + offsetDuty;
+    duty = mapf((float)val, (float)valveMin, (float)joyNeutralMin, DUTY_MIN, DUTY_MID) + offsetDuty;
     active = true;
   } else if (val > joyNeutralMax){
-    duty = mapf((float)val, (float)joyNeutralMax, (float)mapMax, DUTY_MID, DUTY_MAX) + offsetDuty;
+    duty = mapf((float)val, (float)joyNeutralMax, (float)valveMax, DUTY_MID, DUTY_MAX) + offsetDuty;
     active = true;
   }
 
@@ -212,12 +213,17 @@ void processADS(){
   }
 
   ADSRaw rr=readADSRaw(); Axes8 a=mapADSAll(rr);
-  // Inversion de l'axe Z en mode filaire
-  int invZ = neutralOffset * 2 - a.Z;
-  if(invZ < mapMin) invZ = mapMin; else if(invZ > mapMax) invZ = mapMax;
-  a.Z = invZ;
-  applyAxisToPair(0,a.X); applyAxisToPair(1,a.Y); applyAxisToPair(2,a.Z); applyAxisToPair(3,a.LX);
-  applyAxisToPair(4,a.LY); applyAxisToPair(5,a.LZ); applyAxisToPair(6,a.R1); applyAxisToPair(7,a.R2);
+  int vals[AX_COUNT] = {a.X,a.Y,a.Z,a.LX,a.LY,a.LZ,a.R1,a.R2};
+  for(int i=0;i<AX_COUNT;i++){
+    if(invertJoy[i]){
+      int inv = padMapMin[i] + padMapMax[i] - vals[i];
+      if(inv < padMapMin[i]) inv = padMapMin[i];
+      else if(inv > padMapMax[i]) inv = padMapMax[i];
+      vals[i] = inv;
+    }
+  }
+  applyAxisToPair(0,vals[0]); applyAxisToPair(1,vals[1]); applyAxisToPair(2,vals[2]); applyAxisToPair(3,vals[3]);
+  applyAxisToPair(4,vals[4]); applyAxisToPair(5,vals[5]); applyAxisToPair(6,vals[6]); applyAxisToPair(7,vals[7]);
 }
 
 void ioInitI2CAndPCA(){

--- a/IOMap.h
+++ b/IOMap.h
@@ -16,6 +16,7 @@ extern bool adsOK[2];
 extern bool pcaOK;
 
 extern int joyNeutralMin, joyNeutralMax;
+extern int valveMin, valveMax;
 
 void ioInitI2CAndPCA();
 ADSRaw readADSRaw();

--- a/Inversion.cpp
+++ b/Inversion.cpp
@@ -1,0 +1,137 @@
+#include "Inversion.h"
+#include "Portal.h"
+#include <EEPROM.h>
+
+// Tables d'inversion pour joystick filaire et manette
+bool invertJoy[AX_COUNT] = {false,false,true,false,false,false,false,false};
+bool invertPad[AX_COUNT] = {false,false,false,false,false,false,false,false};
+
+#define INV_EE_MAGIC      0x1A55
+#define INV_EE_VER        0x0001
+#define INV_EE_MAGIC_ADDR 292
+#define INV_EE_VER_ADDR   294
+#define INV_EE_DATA_ADDR  296
+
+static const char* AX_NAMES[AX_COUNT] = {"X","Y","Z","LX","LY","LZ","R1","R2"};
+
+void inversionSaveToEEPROM(){
+#if defined(ARDUINO_ARCH_ESP32)
+  EEPROM.begin(512);
+#endif
+  EEPROM.put(INV_EE_MAGIC_ADDR, (uint16_t)INV_EE_MAGIC);
+  EEPROM.put(INV_EE_VER_ADDR, (uint16_t)INV_EE_VER);
+  int addr = INV_EE_DATA_ADDR;
+  for(int i=0;i<AX_COUNT;i++){ uint8_t v = invertJoy[i]?1:0; EEPROM.put(addr++, v); }
+  for(int i=0;i<AX_COUNT;i++){ uint8_t v = invertPad[i]?1:0; EEPROM.put(addr++, v); }
+#if defined(ARDUINO_ARCH_ESP32)
+  EEPROM.commit();
+#endif
+}
+
+static bool inversionLoadFromEEPROM(){
+#if defined(ARDUINO_ARCH_ESP32)
+  EEPROM.begin(512);
+#endif
+  uint16_t magic=0,ver=0;
+  EEPROM.get(INV_EE_MAGIC_ADDR, magic);
+  EEPROM.get(INV_EE_VER_ADDR, ver);
+  if(magic!=INV_EE_MAGIC) return false;
+  int addr = INV_EE_DATA_ADDR;
+  for(int i=0;i<AX_COUNT;i++){ uint8_t b=0; EEPROM.get(addr++, b); invertJoy[i]=(b!=0); }
+  for(int i=0;i<AX_COUNT;i++){ uint8_t b=0; EEPROM.get(addr++, b); invertPad[i]=(b!=0); }
+  return true;
+}
+
+void inversionLoadOrDefault(){
+  if(!inversionLoadFromEEPROM()){
+    for(int i=0;i<AX_COUNT;i++){ invertJoy[i]=false; invertPad[i]=false; }
+    invertJoy[AX_Z]=true; // par défaut, Z inversé pour le joystick
+  }
+}
+
+static String navBar(){
+  return String(
+    "<div class='bar'>"
+      "<a class='btn' href='/defaut'>D\u00E9faut ESP32</a>"
+      "<a class='btn' href='/calib'>Calibration Joystick</a>"
+      "<a class='btn' href='/calev'>Calibration \u00E9lectrovannes</a>"
+      "<a class='btn' href='/bridage'>Bridage axes</a>"
+      "<a class='btn' href='/invjoy'>Inversion Joystick</a>"
+      "<a class='btn' href='/invpad'>Inversion Manette</a>"
+    "</div>"
+    "<style>.bar{display:flex;flex-wrap:wrap;gap:8px;margin:10px 0 16px}"
+    ".btn{background:#334155;color:#e5e7eb;border:1px solid #1f2937;padding:8px 12px;border-radius:8px;text-decoration:none}"
+    ".btn:hover{background:#475569}</style>"
+  );
+}
+
+static String pageHtml(bool joy){
+  String html;
+  html.reserve(4000);
+  html += "<!DOCTYPE html><html><head><meta charset=\"utf-8\">";
+  html += "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">";
+  html += String("<title>Inversion sens ") + (joy?"Joystick":"Manette") + "</title>";
+  html += "<style>";
+  html += ":root{--bg:#0f172a;--fg:#e5e7eb;--line:#1f2937;--btn:#334155;--btnh:#475569;}";
+  html += "body{font-family:system-ui,Arial;margin:0;background:var(--bg);color:var(--fg);}";
+  html += ".wrap{padding:16px;max-width:600px;margin:0 auto;}";
+  html += "table{border-collapse:collapse;width:100%;}";
+  html += "th,td{border-bottom:1px solid var(--line);padding:8px;text-align:left;}";
+  html += "select{background:#111827;color:#e5e7eb;border:1px solid var(--line);border-radius:6px;padding:4px 6px;}";
+  html += "button{margin-top:12px;background:var(--btn);color:var(--fg);border:1px solid var(--line);padding:8px 12px;border-radius:8px;cursor:pointer;}";
+  html += "button:hover{background:var(--btnh)}";
+  html += "#msg{margin-left:10px;color:#9ca3af;}";
+  html += "</style></head><body><div class='wrap'>";
+  html += String("<h2>Inversion sens ") + (joy?"Joystick":"Manette") + "</h2>";
+  html += navBar();
+  html += "<table><tr><th>Axe</th><th>Inversion</th></tr>";
+  for(int i=0;i<AX_COUNT;i++){
+    html += "<tr><td>"; html += AX_NAMES[i]; html += "</td><td><select id='ax"+String(i)+"'>";
+    html += "<option value='0'>Non invers\u00E9</option><option value='1'>Invers\u00E9</option></select></td></tr>";
+  }
+  html += "</table><div class='bar'><button id='send'>Envoyer</button><button id='save'>Sauvegarde EEPROM</button><span id='msg'></span></div>";
+  html += "<script>var CUR=[";
+  bool *arr = joy?invertJoy:invertPad;
+  for(int i=0;i<AX_COUNT;i++){ if(i) html+=","; html += (arr[i]?"1":"0"); }
+  html += "];";
+  html += "function init(){for(var i=0;i<8;i++){document.getElementById('ax'+i).value=CUR[i];}document.getElementById('send').onclick=function(){apply(false);};document.getElementById('save').onclick=function(){apply(true);};}";
+  html += "function apply(s){var v=[];for(var i=0;i<8;i++){v.push(document.getElementById('ax'+i).value);}var msg=document.getElementById('msg');msg.textContent='Envoi...';fetch((s?'/invsave':'/invapply')+'?mode=";
+  html += joy?"joy":"pad";
+  html += "&v='+v.join(','),{cache:'no-store'}).then(function(r){if(!r.ok)throw new Error();return r.text();}).then(function(){msg.textContent=s?'Sauvegard\u00E9':'Appliqu\u00E9';setTimeout(function(){msg.textContent='';},1500);}).catch(function(){msg.textContent='Erreur';});}";
+  html += "init();</script></div></body></html>";
+  return html;
+}
+
+static void parseCSV8bool(const String& s,bool out[AX_COUNT]){
+  int idx=0; String tok="";
+  for(uint16_t i=0;i<=s.length();++i){
+    if(i==s.length() || s[i]==','){ if(idx<AX_COUNT){ out[idx++]=(tok.toInt()!=0); } tok=""; }
+    else tok+=s[i];
+  }
+  while(idx<AX_COUNT) out[idx++]=false;
+}
+
+void inversionMountRoutes(){
+  auto& server = portalServer();
+    server.on("/invjoy", HTTP_GET, [](){ server.send(200,"text/html",pageHtml(true)); });
+    server.on("/invpad", HTTP_GET, [](){ server.send(200,"text/html",pageHtml(false)); });
+    server.on("/invapply", HTTP_GET, [](){
+      if(!server.hasArg("mode") || !server.hasArg("v")){ server.send(400,"text/plain","missing"); return; }
+      bool joy = (server.arg("mode") == "joy");
+      bool tmp[AX_COUNT];
+      parseCSV8bool(server.arg("v"), tmp);
+      if(joy){ for(int i=0;i<AX_COUNT;i++) invertJoy[i]=tmp[i]; }
+      else { for(int i=0;i<AX_COUNT;i++) invertPad[i]=tmp[i]; }
+      server.send(200,"text/plain","OK");
+    });
+    server.on("/invsave", HTTP_GET, [](){
+      if(!server.hasArg("mode") || !server.hasArg("v")){ server.send(400,"text/plain","missing"); return; }
+      bool joy = (server.arg("mode") == "joy");
+      bool tmp[AX_COUNT];
+      parseCSV8bool(server.arg("v"), tmp);
+      if(joy){ for(int i=0;i<AX_COUNT;i++) invertJoy[i]=tmp[i]; }
+      else { for(int i=0;i<AX_COUNT;i++) invertPad[i]=tmp[i]; }
+      inversionSaveToEEPROM();
+      server.send(200,"text/plain","OK");
+    });
+  }

--- a/Inversion.h
+++ b/Inversion.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <Arduino.h>
+#include "Bridage.h"
+
+extern bool invertJoy[AX_COUNT];
+extern bool invertPad[AX_COUNT];
+
+void inversionLoadOrDefault();
+void inversionSaveToEEPROM();
+void inversionMountRoutes();

--- a/Portal.cpp
+++ b/Portal.cpp
@@ -20,8 +20,11 @@ static String homePage(){
     "</style></head><body>"
     "<h2>ESP32 Contr\u00F4le</h2>"
     "<a href='/defaut'>D\u00E9faut ESP32</a>"
-    "<a href='/calib'>Calibration</a>"
+    "<a href='/calib'>Calibration Joystick</a>"
+    "<a href='/calev'>Calibration \u00E9lectrovannes</a>"
     "<a href='/bridage'>Bridage axes</a>"
+    "<a href='/invjoy'>Inversion sens Joystick</a>"
+    "<a href='/invpad'>Inversion sens Manette</a>"
     "</body></html>"
   );
 }

--- a/ValveCalib.cpp
+++ b/ValveCalib.cpp
@@ -1,0 +1,123 @@
+#include "ValveCalib.h"
+#include "IOMap.h"
+#include "Portal.h"
+#include <EEPROM.h>
+
+static uint16_t evNeutral = 512;
+static uint16_t evMin = 255;
+static uint16_t evMax = 768;
+
+#define EV_EE_MAGIC      0xE1A1
+#define EV_EE_VER        0x0001
+#define EV_EE_MAGIC_ADDR 312
+#define EV_EE_VER_ADDR   314
+#define EV_EE_NEU_ADDR   316
+#define EV_EE_MIN_ADDR   318
+#define EV_EE_MAX_ADDR   320
+
+void valveCalibLoad(){
+  loadNeutralOffset();
+#if defined(ARDUINO_ARCH_ESP32)
+  EEPROM.begin(512);
+#endif
+  uint16_t magic=0, ver=0;
+  EEPROM.get(EV_EE_MAGIC_ADDR, magic);
+  EEPROM.get(EV_EE_VER_ADDR, ver);
+  if(magic==EV_EE_MAGIC){
+    EEPROM.get(EV_EE_NEU_ADDR, evNeutral);
+    EEPROM.get(EV_EE_MIN_ADDR, evMin);
+    EEPROM.get(EV_EE_MAX_ADDR, evMax);
+    neutralOffset = evNeutral;
+    valveMin = evMin;
+    valveMax = evMax;
+  } else {
+    evNeutral = neutralOffset;
+    evMin = valveMin;
+    evMax = valveMax;
+  }
+  updateNeutralWindow();
+}
+
+static void valveCalibSaveToEEPROM(){
+#if defined(ARDUINO_ARCH_ESP32)
+  EEPROM.begin(512);
+#endif
+  EEPROM.put(EV_EE_MAGIC_ADDR, (uint16_t)EV_EE_MAGIC);
+  EEPROM.put(EV_EE_VER_ADDR,   (uint16_t)EV_EE_VER);
+  EEPROM.put(EV_EE_NEU_ADDR,   evNeutral);
+  EEPROM.put(EV_EE_MIN_ADDR,   evMin);
+  EEPROM.put(EV_EE_MAX_ADDR,   evMax);
+#if defined(ARDUINO_ARCH_ESP32)
+  EEPROM.commit();
+#endif
+  saveNeutralOffset();
+}
+
+static inline int clampInt(int v,int lo,int hi){ if(v<lo) return lo; if(v>hi) return hi; return v; }
+
+static String navBar(){
+  return String(
+    "<div class='bar'>"
+      "<a class='btn' href='/defaut'>D\u00E9faut ESP32</a>"
+      "<a class='btn' href='/calib'>Calibration Joystick</a>"
+      "<a class='btn' href='/calev'>Calibration \u00E9lectrovannes</a>"
+      "<a class='btn' href='/bridage'>Bridage axes</a>"
+      "<a class='btn' href='/invjoy'>Inversion Joystick</a>"
+      "<a class='btn' href='/invpad'>Inversion Manette</a>"
+    "</div>"
+    "<style>.bar{display:flex;flex-wrap:wrap;gap:8px;margin:10px 0 16px}"
+    ".btn{background:#334155;color:#e5e7eb;border:1px solid #1f2937;padding:8px 12px;border-radius:8px;text-decoration:none}"
+    ".btn:hover{background:#475569}</style>"
+  );
+}
+
+static String htmlPage(){
+  String html;
+  html.reserve(6000);
+  html += "<!DOCTYPE html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'>";
+  html += "<title>Calibration \u00E9lectrovannes</title><style>";
+  html += "body{font-family:system-ui,Arial;margin:16px;background:#0f172a;color:#e5e7eb}";
+  html += "button{background:#334155;color:#e5e7eb;border:1px solid #1f2937;padding:8px 12px;border-radius:8px;cursor:pointer;margin-right:8px;}";
+  html += "button:hover{background:#475569}";
+  html += "input[type=range]{width:100%;margin:12px 0;}";
+  html += "#msg,#msg2{color:#9ca3af;margin-left:10px}";
+  html += "</style></head><body><h2>Calibration \u00E9lectrovannes</h2>";
+  html += navBar();
+  html += "<div id='step0'><button id='start'>D\u00E9marrer la calibration</button></div>";
+  html += "<div id='count' style='display:none'>D\u00E9marrage dans <span id='cd'>5</span>s <button id='cancel'>Annuler</button></div>";
+  html += "<div id='cal' style='display:none'>";
+  html += "<p id='phase'></p><input type='range' id='sl' min='0' max='1023' value='512'>";
+  html += "<div><button id='minus'>-</button><button id='plus'>+</button><button id='send'>Envoyer</button><button id='next'>Enregistrer</button><span id='msg'></span></div>";
+  html += "</div><div id='save' style='display:none'><button id='saveBtn'>Sauvegarde</button><span id='msg2'></span></div>";
+  html += "<script>var ph=0;var labels=['Neutre','Mini','Maxi'];function upd(){document.getElementById('phase').textContent='Phase '+(ph+1)+' - '+labels[ph];}function start(){document.getElementById('step0').style.display='none';document.getElementById('count').style.display='block';var c=5;document.getElementById('cd').textContent=c;var t=setInterval(function(){c--;document.getElementById('cd').textContent=c;if(c<=0){clearInterval(t);document.getElementById('count').style.display='none';document.getElementById('cal').style.display='block';fetch('/calev/start');upd();}},1000);document.getElementById('cancel').onclick=function(){clearInterval(t);document.getElementById('count').style.display='none';document.getElementById('step0').style.display='block';};}document.getElementById('start').onclick=start;document.getElementById('plus').onclick=function(){var s=document.getElementById('sl');s.value=Math.min(1023,parseInt(s.value)+1);};document.getElementById('minus').onclick=function(){var s=document.getElementById('sl');s.value=Math.max(0,parseInt(s.value)-1);};document.getElementById('send').onclick=function(){var v=document.getElementById('sl').value;var m=document.getElementById('msg');m.textContent='Envoi...';fetch('/calev/set?v='+v).then(function(){m.textContent='Reçu';setTimeout(function(){m.textContent='';},1500);});};document.getElementById('next').onclick=function(){var v=document.getElementById('sl').value;fetch('/calev/record?phase='+ph+'&val='+v).then(function(){ph++;if(ph<3){upd();}else{document.getElementById('cal').style.display='none';document.getElementById('save').style.display='block';}});};document.getElementById('saveBtn').onclick=function(){var m=document.getElementById('msg2');m.textContent='Envoi...';fetch('/calev/save').then(function(){m.textContent='Sauvegard\u00E9';setTimeout(function(){m.textContent='';},1500);});};</script>";
+  html += "</body></html>";
+  return html;
+}
+
+void valveCalibMountRoutes(){
+  auto& server = portalServer();
+  server.on("/calev", HTTP_GET, [](){ server.send(200,"text/html",htmlPage()); });
+  server.on("/calev/start", HTTP_GET, [](){ neutralizeAllOutputs(); server.send(200,"text/plain","OK"); });
+  server.on("/calev/set", HTTP_GET, [](){
+    if(!server.hasArg("v")){ server.send(400,"text/plain","missing"); return; }
+    int v = clampInt(server.arg("v").toInt(),0,1023);
+    applyAxisToPair(0,v);
+    server.send(200,"text/plain","OK");
+  });
+  server.on("/calev/record", HTTP_GET, [](){
+    if(!server.hasArg("phase") || !server.hasArg("val")){ server.send(400,"text/plain","missing"); return; }
+    int ph = server.arg("phase").toInt();
+    int v = clampInt(server.arg("val").toInt(),0,1023);
+    if(ph==0) evNeutral=v; else if(ph==1) evMin=v; else if(ph==2) evMax=v;
+    server.send(200,"text/plain","OK");
+  });
+  server.on("/calev/save", HTTP_GET, [](){
+    neutralOffset = evNeutral;
+    valveMin = evMin;
+    valveMax = evMax;
+    updateNeutralWindow();
+    valveCalibSaveToEEPROM();
+    server.send(200,"text/plain","OK");
+  });
+}
+

--- a/ValveCalib.h
+++ b/ValveCalib.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <Arduino.h>
+
+void valveCalibLoad();
+void valveCalibMountRoutes();
+


### PR DESCRIPTION
## Summary
- add calibration page for electrovalves with countdown, slider and EEPROM persistence
- add send and EEPROM save buttons to axis inversion pages
- update navigation to expose joystick and electrovalve calibration pages

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 ./ESP32_PVG32_Controller.ino` *(fails: command not found)*
- `apt-get update && apt-get install -y arduino-cli` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be458d1c3c8327ae277f55e7f8f862